### PR TITLE
Make renovate pin GitHub actions

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -3,7 +3,11 @@
 
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   reuse-lint:

--- a/default.json
+++ b/default.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     "docker:enableMajor",
-    ":automergeMinor"
+    ":automergeMinor",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["Renovate"],
   "dependencyDashboardLabels": ["Renovate"],


### PR DESCRIPTION
It's a security best practice without any extra effort for us